### PR TITLE
Use local flutter SDK instead of downloading files

### DIFF
--- a/bots/run.sh
+++ b/bots/run.sh
@@ -24,5 +24,4 @@ flutter analyze
 popd
 
 echo "Generating all content"
-# TODO(dantup): Remove "generate" from the end after #8 lands.
-flutter pub run grinder generate
+flutter pub run grinder

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,4 +12,3 @@ dependencies:
 
 dev_dependencies:
   grinder: ^0.8.0
-  http: ^0.12.0

--- a/tool/catalog/generate_widget_catalog.dart
+++ b/tool/catalog/generate_widget_catalog.dart
@@ -21,7 +21,6 @@ Future<void> main(List<String> args) async {
     fail('Please run this tool from the root of the repo.');
   }
 
-  final String flutterSdkPath = getFlutterSdkPath();
   final String flutterPackagePath =
       path.absolute(path.join(flutterSdkPath, 'packages/flutter/lib'));
 

--- a/tool/colors/flutter/colors_cupertino.dart
+++ b/tool/colors/flutter/colors_cupertino.dart
@@ -1,4 +1,4 @@
-// This file was downloaded by update_colors.dart.
+// This file was copied from the Flutter SDK by update_colors.dart.
 
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/tool/colors/flutter/colors_material.dart
+++ b/tool/colors/flutter/colors_material.dart
@@ -1,4 +1,4 @@
-// This file was downloaded by update_colors.dart.
+// This file was copied from the Flutter SDK by update_colors.dart.
 
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/tool/colors/update_colors.dart
+++ b/tool/colors/update_colors.dart
@@ -55,7 +55,7 @@ import '../stubs.dart';
 \n''');
 
   file.writeAsStringSync(
-    '// This file was downloaded by update_colors.dart.\n\n'
+    '// This file was copied from the Flutter SDK by update_colors.dart.\n\n'
     '$contents',
   );
 }

--- a/tool/common.dart
+++ b/tool/common.dart
@@ -9,7 +9,9 @@ import 'package:path/path.dart' as path;
 
 const String flutterBranch = 'dev';
 
-String getFlutterSdkPath() {
+final String flutterSdkPath = _getFlutterSdkPath();
+
+String _getFlutterSdkPath() {
   // This depends on the dart SDK being in <flutter-sdk>/bin/cache/dart-sdk/bin.
   if (!Platform.resolvedExecutable.contains('bin/cache/dart-sdk')) {
     throw 'Please run this script from the version of dart in the Flutter SDK.';
@@ -20,7 +22,7 @@ String getFlutterSdkPath() {
 }
 
 Map<String, String> calculateFlutterVersion() {
-  final String flutterPath = path.join(getFlutterSdkPath(), 'bin/flutter');
+  final String flutterPath = path.join(flutterSdkPath, 'bin/flutter');
   final ProcessResult result =
       Process.runSync(flutterPath, <String>['--version', '--machine']);
   if (result.exitCode != 0) {

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -13,7 +13,7 @@ import 'common.dart';
 Future<void> main(List<String> args) => grind(args);
 
 @DefaultTask()
-@Depends(analysisOptions, colors, icons, catalog, version)
+@Depends(version, analysisOptions, colors, icons, catalog)
 void generate() {}
 
 @Task('Sync analysis_options from Flutter')
@@ -61,6 +61,12 @@ Future<void> catalog() async {
 @Task('Generate the version.json file')
 Future<void> version() async {
   final Map<String, String> versionInfo = calculateFlutterVersion();
+
+  final String actualChannel = versionInfo['channel'];
+  if (actualChannel != flutterBranch) {
+    throw 'You are currently using the Flutter $actualChannel channel, please '
+        'generate these files using the $flutterBranch channel.';
+  }
 
   final File versionFile = File('resources/version.json');
   const JsonEncoder encoder = JsonEncoder.withIndent('  ');

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -6,7 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:grinder/grinder.dart';
-import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as path;
 
 import 'common.dart';
 
@@ -18,32 +18,27 @@ void generate() {}
 
 @Task('Sync analysis_options from Flutter')
 Future<void> analysisOptions() async {
-  // TODO(dantup): Use this from the local Flutter checkout.
-  const String analysisOptionsUrl =
-      'https://raw.githubusercontent.com/flutter/flutter/$flutterBranch/analysis_options.yaml';
-  final http.Client client = http.Client();
-  try {
-    final http.Response resp = await client.get(analysisOptionsUrl);
+  final String flutterAnalysisOptionsContents =
+      File(path.join(flutterSdkPath, 'analysis_options.yaml'))
+          .readAsStringSync();
 
-    // Additional exclusion for this project.
-    final String additionalExclusions = <String>[
-      'bots/temp/**',
-      'tool/icon_generator/**',
-    ].map((String ex) => "    - '$ex'\n").join();
+  // Additional exclusion for this project.
+  final String additionalExclusions = <String>[
+    'bots/temp/**',
+    'tool/icon_generator/**',
+  ].map((String ex) => "    - '$ex'\n").join();
 
-    // Insert them into the correct place in the analysis_options content.
-    final String analysisOptionsContents = resp.body.replaceAll(
-      '\n  exclude:\n',
-      '\n  exclude:\n$additionalExclusions',
-    );
+  // Insert them into the correct place in the analysis_options content.
+  final String analysisOptionsContents =
+      flutterAnalysisOptionsContents.replaceAll(
+    '\n  exclude:\n',
+    '\n  exclude:\n$additionalExclusions',
+  );
 
-    File('analysis_options.yaml').writeAsStringSync(
-      '# This file is downloaded from the Flutter repository in grind.dart.\n\n'
-      '$analysisOptionsContents\n',
-    );
-  } finally {
-    client.close();
-  }
+  File('analysis_options.yaml').writeAsStringSync(
+    '# This file is downloaded from the Flutter repository in grind.dart.\n\n'
+    '$analysisOptionsContents\n',
+  );
 }
 
 @Task('Generate Flutter color information')

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -68,6 +68,13 @@ Future<void> version() async {
         'generate these files using the $flutterBranch channel.';
   }
 
+  // Avoid generating needless diffs by mapping SSH clones onto the HTTPS URL.
+  // - git@github.com:flutter/flutter.git (SSH)
+  // - https://github.com/flutter/flutter (HTTPS)
+  versionInfo['repositoryUrl'] = versionInfo['repositoryUrl']
+      .replaceAll('git@github.com:', 'https://github.com/')
+      .replaceAll(RegExp(r'.git$'), '');
+
   final File versionFile = File('resources/version.json');
   const JsonEncoder encoder = JsonEncoder.withIndent('  ');
   versionFile.writeAsStringSync('${encoder.convert(versionInfo)}\n');

--- a/tool/icons/update_icons.dart
+++ b/tool/icons/update_icons.dart
@@ -10,14 +10,12 @@ import '../common.dart';
 const String outputFolder = 'resources/icons';
 
 Future<void> main() async {
-  // download material/icons.dart and cupertino/icons.dart
-  // TODO(dantup): Use this from the local Flutter checkout.
   final String materialData =
-      await downloadUrl('https://raw.githubusercontent.com/flutter/flutter/'
-          '$flutterBranch/packages/flutter/lib/src/material/icons.dart');
+      File('$flutterSdkPath/packages/flutter/lib/src/material/icons.dart')
+          .readAsStringSync();
   final String cupertinoData =
-      await downloadUrl('https://raw.githubusercontent.com/flutter/flutter/'
-          '$flutterBranch/packages/flutter/lib/src/cupertino/icons.dart');
+      File('$flutterSdkPath/packages/flutter/lib/src/cupertino/icons.dart')
+          .readAsStringSync();
 
   // parse into metadata
   final List<Icon> materialIcons = parseIconData(materialData);


### PR DESCRIPTION
- changes code from downloading files to just reading the local SDK directly
- throw if the local SDK doesn't match the expected channel (currently dev)
- prevent generating diffs in the version file if your Flutter SDK was cloned using ssh

Note: We still do *copy* some files from Flutter which we rewrite the imports for (to use our stubs). It might be possible we can eliminate this (and just them directly), but that's a bigger change than just avoiding the downloads, so not done here.