### PR TITLE
Migrate to null-safe code, upgrade packages, fix NPE on mixins

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,8 +2,7 @@ include: package:lints/recommended.yaml
 
 analyzer:
   exclude:
-    - 'bots/temp/**'
-    - 'tool/icon_generator/**'
+    - "bots/temp/**"
     - "bin/cache/**"
     # the following two are relative to the stocks example and the flutter package respectively
     # see https://github.com/dart-lang/sdk/issues/28463

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,17 @@
 name: tool_metadata
 
 environment:
-  sdk: ">=2.8.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  analyzer: ^0.40.0
+  analyzer: ^3.3.1
   args: any
+  collection:
   css_colors: ^1.1.1
   flutter:
     sdk: flutter
-  path: ^1.7.0
+  path: ^1.8.1
 
 dev_dependencies:
-  grinder: ^0.8.0
-  lints: ^1.0.0
+  grinder: ^0.9.0
+  lints: ^1.0.1

--- a/tool/colors/generate_files.dart
+++ b/tool/colors/generate_files.dart
@@ -101,20 +101,21 @@ void generateJson(Map<String, Color> colors, String filename) {
 
 void writeColors(Map<String, Color> colors,
     void Function(String name, Color value) writeColor) {
-  for (final String name in colors.keys) {
-    final Color color = colors[name];
+  for (final MapEntry<String, Color> entry in colors.entries) {
+    final String name = entry.key;
+    final Color color = entry.value;
     if (color is MaterialColor) {
       writeColor('$name.primary', color);
       for (final int shade in validShades) {
         if (color[shade] != null) {
-          writeColor('$name[$shade]', color[shade]);
+          writeColor('$name[$shade]', color[shade]!);
         }
       }
     } else if (color is MaterialAccentColor) {
       writeColor('$name.primary', color);
       for (final int shade in validShades) {
         if (color[shade] != null) {
-          writeColor('$name[$shade]', color[shade]);
+          writeColor('$name[$shade]', color[shade]!);
         }
       }
     } else if (color is CupertinoDynamicColor) {

--- a/tool/colors/update_colors.dart
+++ b/tool/colors/update_colors.dart
@@ -15,7 +15,6 @@ final File materialColorsFile =
     File('$flutterPackageSourcePath/material/colors.dart');
 final File cupertinoColorsFile =
     File('$flutterPackageSourcePath/cupertino/colors.dart');
-File cssColorsFile;
 const String generatedFilesPath = 'tool/colors/generated';
 
 Future<void> main(List<String> args) async {
@@ -31,9 +30,9 @@ Future<void> main(List<String> args) async {
 
 Future<void> generateDartFiles() async {
   // Get the path to the source file
-  cssColorsFile = File((await Isolate.resolvePackageUri(
-          Uri.parse('package:css_colors/css_colors.dart')))
-      .toFilePath());
+  final cssColorsPackageUri = await Isolate.resolvePackageUri(
+      Uri.parse('package:css_colors/css_colors.dart'));
+  final cssColorsFile = File(cssColorsPackageUri!.toFilePath());
 
   // parse into metadata
   final List<String> materialColors = extractColorNames(materialColorsFile);
@@ -45,8 +44,8 @@ Future<void> generateDartFiles() async {
       'package:flutter/src/material/colors.dart');
   generateDart(cupertinoColors, 'cupertino', 'CupertinoColors',
       'package:flutter/src/cupertino/colors.dart');
-  generateDart(cssColors, 'css', 'CSSColors',
-      'package:css_colors/css_colors.dart');
+  generateDart(
+      cssColors, 'css', 'CSSColors', 'package:css_colors/css_colors.dart');
 }
 
 // The pattern below is meant to match lines like:
@@ -61,7 +60,7 @@ List<String> extractColorNames(File file) {
 
   final List<String> names = regexpColor
       .allMatches(data)
-      .map((Match match) => match.group(1))
+      .map((Match match) => match.group(1)!)
       .toList();
 
   // Remove any duplicates.

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -36,7 +36,7 @@ Future<void> catalog() async {
 Future<void> version() async {
   final Map<String, String> versionInfo = calculateFlutterVersion();
 
-  final String actualChannel = versionInfo['channel'];
+  final String actualChannel = versionInfo['channel']!;
   if (actualChannel != flutterBranch) {
     throw 'You are currently using the Flutter $actualChannel channel, please '
         'generate these files using the $flutterBranch channel.';
@@ -45,7 +45,7 @@ Future<void> version() async {
   // Avoid generating needless diffs by mapping SSH clones onto the HTTPS URL.
   // - git@github.com:flutter/flutter.git (SSH)
   // - https://github.com/flutter/flutter (HTTPS)
-  versionInfo['repositoryUrl'] = versionInfo['repositoryUrl']
+  versionInfo['repositoryUrl'] = versionInfo['repositoryUrl']!
       .replaceAll('git@github.com:', 'https://github.com/')
       .replaceAll(RegExp(r'.git$'), '');
 

--- a/tool/icon_generator/lib/main.dart
+++ b/tool/icon_generator/lib/main.dart
@@ -150,7 +150,8 @@ Future findAndSave(Key key, String path, {bool small: true}) async {
   Future<ui.Image> imageFuture = _captureImage(element);
 
   final ui.Image image = await imageFuture;
-  final ByteData bytes = await image.toByteData(format: ui.ImageByteFormat.png);
+  final ByteData bytes =
+      (await image.toByteData(format: ui.ImageByteFormat.png))!;
 
   await new File(path).writeAsBytes(bytes.buffer.asUint8List());
 
@@ -158,15 +159,13 @@ Future findAndSave(Key key, String path, {bool small: true}) async {
 }
 
 Future<ui.Image> _captureImage(Element element) {
-  RenderObject renderObject = element.renderObject;
+  // Copied from package:flutter_test/src/_matchers_io.dart.
+  assert(element.renderObject != null);
+  RenderObject renderObject = element.renderObject!;
   while (!renderObject.isRepaintBoundary) {
-    renderObject = renderObject.parent;
-    assert(renderObject != null);
+    renderObject = renderObject.parent! as RenderObject;
   }
-
   assert(!renderObject.debugNeedsPaint);
-
-  // ignore: invalid_use_of_protected_member
-  final OffsetLayer layer = renderObject.layer;
+  final OffsetLayer layer = renderObject.debugLayer! as OffsetLayer;
   return layer.toImage(renderObject.paintBounds);
 }

--- a/tool/icon_generator/pubspec.yaml
+++ b/tool/icon_generator/pubspec.yaml
@@ -3,7 +3,7 @@ description: Generates preview images for the Material and Cupertino icons.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.8.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -11,7 +11,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.0
+  cupertino_icons: ^1.0.4
 
 dev_dependencies:
   flutter_test:

--- a/tool/icons/update_icons.dart
+++ b/tool/icons/update_icons.dart
@@ -59,7 +59,7 @@ final RegExp regexp =
 
 List<Icon> parseIconData(String data) {
   return regexp.allMatches(data).map((Match match) {
-    return Icon(match.group(1), int.parse(match.group(2), radix: 16));
+    return Icon(match.group(1)!, int.parse(match.group(2)!, radix: 16));
   }).toList();
 }
 


### PR DESCRIPTION
This fixes the NPE noted at https://github.com/flutter/tools_metadata/pull/30#issuecomment-1059408739 which was caused by a mixin (`SlottedMultiChildRenderObjectWidgetMixin`) which extends `Widget` but is not a class so does not have a `supertype`.

Additionally, it upgrades all packages and code to null-safe. There are a lot of places with non-null assertions `!`, but they're places where I think we expect they will never be null and probably not worth coding around right now (and if these assertions fail in future, there will be an example to help inform how that case should be handled).

There were some breaking changes in the Analyzer package since the version this was using, so there are a few changes to handle that (such as `getSourceKind` being removed), and it also seems like the formatter has had some minor tweaks too (so there are a few small formatting changes for code that wasn't actually modified).

This was all run and testing with the current beta branch:

```
Flutter 2.11.0-0.1.pre • channel beta • git@github.com:flutter/flutter.git
Framework • revision b101bfe32f (3 weeks ago) • 2022-02-16 07:36:54 -0800
Engine • revision e355993572
Tools • Dart 2.17.0 (build 2.17.0-69.2.beta) • DevTools 2.10.0-dev.1
```

@devoncarew 