### PR TITLE
use SHAs for workflow files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
+
 updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
       interval: "weekly"
+  labels:
+      - autosubmit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,5 +7,5 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
     - run: ./bots/run.sh

--- a/.github/workflows/check_up_to_date.yaml
+++ b/.github/workflows/check_up_to_date.yaml
@@ -10,5 +10,5 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - run: ./bots/check_up_to_date.sh


### PR DESCRIPTION
- use SHAs for workflow files (SHAs are preferrable to git tags)
- apply the `autosubmit` label to dependabot PRs
