### PR TITLE
Update to latest beta

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,5 +14,5 @@ dependencies:
 
 dev_dependencies:
   grinder: ^0.9.4
-  lints: ^2.1.1
+  lints: ^3.0.0
   yaml: ^3.1.2

--- a/resources/catalog/widgets.json
+++ b/resources/catalog/widgets.json
@@ -1,6 +1,6 @@
 {
   "flutter": {
-    "version": "3.16.0-0.1.pre",
+    "version": "3.22.0-0.1.pre",
     "channel": "beta"
   },
   "widgets": [
@@ -301,7 +301,7 @@
     },
     {
       "name": "Banner",
-      "parent": "StatelessWidget",
+      "parent": "StatefulWidget",
       "library": "widgets",
       "description": "Displays a diagonal message above the corner of another widget."
     },
@@ -1398,7 +1398,7 @@
       "name": "HtmlElementView",
       "parent": "StatelessWidget",
       "library": "widgets",
-      "description": "Embeds an HTML element in the Widget hierarchy in Flutter Web."
+      "description": "Embeds an HTML element in the Widget hierarchy in Flutter web."
     },
     {
       "name": "Icon",
@@ -2049,7 +2049,7 @@
       "name": "PopScope",
       "parent": "StatefulWidget",
       "library": "widgets",
-      "description": "Manages system back gestures."
+      "description": "Manages back navigation gestures."
     },
     {
       "name": "PopupMenuButton",
@@ -2919,7 +2919,7 @@
       "name": "TapRegion",
       "parent": "SingleChildRenderObjectWidget",
       "library": "widgets",
-      "description": "A widget that defines a region that can detect taps inside or outside of itself and any group of regions it belongs to, without participating in the [gesture disambiguation](https://flutter.dev/gestures/#gesture-disambiguation) system."
+      "description": "A widget that defines a region that can detect taps inside or outside of itself and any group of regions it belongs to, without participating in the [gesture disambiguation](https://flutter.dev/gestures/#gesture-disambiguation) system (other than to consume tap down events if [consumeOutsideTaps] is true)."
     },
     {
       "name": "TapRegionSurface",
@@ -3051,7 +3051,7 @@
       "name": "TooltipTheme",
       "parent": "InheritedTheme",
       "library": "material",
-      "description": "An inherited widget that defines the configuration for [Tooltip]s in this widget's subtree."
+      "description": "Applies a tooltip theme to descendant [Tooltip] widgets."
     },
     {
       "name": "TooltipVisibility",

--- a/resources/version.json
+++ b/resources/version.json
@@ -1,11 +1,11 @@
 {
-  "frameworkVersion": "3.16.0-0.1.pre",
+  "frameworkVersion": "3.22.0-0.1.pre",
   "channel": "beta",
   "repositoryUrl": "https://github.com/flutter/flutter",
-  "frameworkRevision": "f0abad66b249244cbdbb291cf6edfbba9937ffa0",
-  "frameworkCommitDate": "2023-10-10 19:29:41 -0700",
-  "engineRevision": "7ccdde78a7d174dc0bf0be77102b205e844c7998",
-  "dartSdkVersion": "3.2.0 (build 3.2.0-210.1.beta)",
-  "devToolsVersion": "2.28.1",
-  "flutterVersion": "3.16.0-0.1.pre"
+  "frameworkRevision": "29babcb32a591b9e5be8c6a6075d4fe605d46ad3",
+  "frameworkCommitDate": "2024-04-03 17:17:04 -0500",
+  "engineRevision": "97550907b70f4f3b328b6c1600df21fac1a1889a",
+  "dartSdkVersion": "3.4.0 (build 3.4.0-282.1.beta)",
+  "devToolsVersion": "2.34.2",
+  "flutterVersion": "3.22.0-0.1.pre"
 }

--- a/tool/icon_generator/pubspec.yaml
+++ b/tool/icon_generator/pubspec.yaml
@@ -3,7 +3,7 @@ description: Generates preview images for the Material and Cupertino icons.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -13,7 +13,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.4
+  cupertino_icons: ^1.0.8
   yaml: ^3.1.1
   path: ^1.9.0
 


### PR DESCRIPTION
This updates everything for the latest beta.

There were no new icons, but around 2600 icons did change in subtle ways - in many cases they seem misaligned to me (see https://github.com/flutter/flutter/issues/143069), but since this beta is likely to release soon, I think it's better to be updated than not.

I split into two commits for the non-icon/icon changes, because GH usually struggled to load the icon changes 😔

(Seems like bots are red already on main, I will look at that for another PR).