### PR TITLE
Force a build every week

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,16 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    # 10am, every Monday
+    - cron: '0 10 * * 1'
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - run: ./bots/run.sh


### PR DESCRIPTION
This makes the normal build run every week. There's an existing check-up-to-date check run every month, but it doesn't do things like analysis.

(the `workflow_dispatch` check allows [triggering the build manually](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) and we have it on the other job but not here)

@devoncarew 